### PR TITLE
Printf.fix_dec and ini_dec for Julia v1.0

### DIFF
--- a/src/type/show.jl
+++ b/src/type/show.jl
@@ -45,20 +45,18 @@ showall(x::DoubleFloat{T}) where {T<:IEEEFloat} = print(Base.stdout, string(x))
 showall(x::Complex{DoubleFloat{T}}) where {T<:IEEEFloat} = print(Base.stdout, string(x))
 
 
-Base.Printf.fix_dec(x::Double64, n::Int, digits) =
-    Base.Printf.fix_dec(Float64(x),n,digits)
-
-Base.Printf.fix_dec(x::Double32, n::Int, digits) =
-    Base.Printf.fix_dec(Float64(x),n,digits)
-
-Base.Printf.fix_dec(x::Double16, n::Int, digits) =
-    Base.Printf.fix_dec(Float32(x),n,digits)
-
-Base.Printf.ini_dec(x::Double64, n::Int, digits) =
-    Base.Printf.ini_dec(Float64(x),n,digits)
-
-Base.Printf.ini_dec(x::Double32, n::Int, digits) =
-    Base.Printf.ini_dec(Float64(x),n,digits)
-
-Base.Printf.ini_dec(x::Double16, n::Int, digits) =
-    Base.Printf.ini_dec(Float32(x),n,digits)
+if VERSION < v"1.1"
+    Base.Printf.fix_dec(x::Double64, n::Int) = Base.Printf.fix_dec(Float64(x), n)
+    Base.Printf.fix_dec(x::Double32, n::Int) = Base.Printf.fix_dec(Float64(x), n)
+    Base.Printf.fix_dec(x::Double16, n::Int) = Base.Printf.fix_dec(Float32(x), n)
+    Base.Printf.ini_dec(x::Double64, n::Int) = Base.Printf.ini_dec(Float64(x), n)
+    Base.Printf.ini_dec(x::Double32, n::Int) = Base.Printf.ini_dec(Float64(x), n)
+    Base.Printf.ini_dec(x::Double16, n::Int) = Base.Printf.ini_dec(Float32(x), n)
+else   
+    Base.Printf.fix_dec(x::Double64, n::Int, digits) = Base.Printf.fix_dec(Float64(x), n, digits)
+    Base.Printf.fix_dec(x::Double32, n::Int, digits) = Base.Printf.fix_dec(Float64(x), n, digits)
+    Base.Printf.fix_dec(x::Double16, n::Int, digits) = Base.Printf.fix_dec(Float32(x), n, digits)
+    Base.Printf.ini_dec(x::Double64, n::Int, digits) = Base.Printf.ini_dec(Float64(x), n, digits)
+    Base.Printf.ini_dec(x::Double32, n::Int, digits) = Base.Printf.ini_dec(Float64(x), n, digits)
+    Base.Printf.ini_dec(x::Double16, n::Int, digits) = Base.Printf.ini_dec(Float32(x), n, digits)
+end


### PR DESCRIPTION
On Julia v1.0, I'm getting this error.
```
Julia-1.0.4> using Printf

Julia-1.0.4> using DoubleFloats

Julia-1.0.4> @printf("%f", Double64(3))
ERROR: StackOverflowError:
```
I think this is issue #81 for Julia v1.0
